### PR TITLE
Added websites for AI

### DIFF
--- a/courses/CSF407/README.md
+++ b/courses/CSF407/README.md
@@ -35,4 +35,6 @@ This course has no prerequisites.
 
 * [AI Tutorial, *javatpoint*](https://www.javatpoint.com/artificial-intelligence-tutorial)
 * [AI Course, *University of Texas*](https://www.cs.utexas.edu/~mooney/cs343/)
+* [AI Course, *University of California*](https://inst.eecs.berkeley.edu/~cs188/fa22/)
+* [Introduction to ML and DL, *Medium*](https://medium.com/intuitive-deep-learning/introduction/home)
 


### PR DESCRIPTION
`https://inst.eecs.berkeley.edu/~cs188/fa22/`
Found the website which Sujala ma'am uses for teaching AI. Contains slides and corresponding short notes.

`https://medium.com/intuitive-deep-learning/introduction/home`
Another link shared by Sujala ma'am which introduces and explains NN, RNN and CNN